### PR TITLE
Fixes #11: provide an example of a demo deployment of secrets-manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ And then generate a token associated to that role
 `$ vault token create -role="secrets-manager`
 
 ## Deployment
-*secrets-manager* has been designed to be deployed in Kubernetes as it reads its config file from Kubernetes Configmap. Future versions of *secrets-manager* may use Custom Resource Definitions instead.
+*secrets-manager* has been designed to be deployed in Kubernetes as it reads its config file from Kubernetes Configmap. Future versions of *secrets-manager* may use Custom Resource Definitions instead. You will find a full deployment example in the [examples/](examples) folder.
 
 ## Credits & Contact
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,51 @@
+# Simple Secrets Manager Example
+
+This is an example guide to perform a simple deployment of secrets-manager in K8s. It will deploy _secrets-manager_ in `default` namespace. It also includes a dummy Vault deployment but you can use your own if you already have a Vault instance. 
+
+
+## Deploy Vault
+
+If you already have a Vault instance, you can skip this step.
+
+```bash
+kubectl apply -f vault.yaml
+```
+
+## Generate a Vault token 
+... and store it in a K8s secret. If you are going to use your current Vault instance you don't need the first line, just generate a Vault token as usual and go straight to second line to create it.
+
+```bash
+VAULT_TOKEN=$(kubectl exec $(kubectl get pods -l app=vault -o custom-columns=:metadata.name) -c vault -- vault token create --field=token)
+
+kubectl create secret generic --from-literal=token=$VAULT_TOKEN vault-token-secret
+
+```
+
+## Deploy Secrets Manager
+
+The K8s manifests in [secrets-manager.yaml](secrets-manager.yaml) will configure to _secrets-manager_ to fetch secrets from the dummy Vault deployment, but you can change the configmap content to use your own secrets.
+
+```
+kubectl apply -f secrets-manager.yaml
+```
+
+If you check the _secrets-manager_ logs, you will see after a while that it's updating the K8s secrets with the content from Vault.
+
+```
+➜  kubectl logs $(kubectl get pods -l app=demo-secrets-manager -o custom-columns=:metadata.name)
+time="2018-11-28T00:15:00Z" level=info msg="successfully logged in to Vault cluster vault-cluster-0587b7b9"
+time="2018-11-28T00:15:15Z" level=info msg="secret 'default/supersecret1' must be updated"
+time="2018-11-28T00:15:15Z" level=info msg="secret 'default/supersecret1' updated"
+time="2018-11-28T00:15:15Z" level=info msg="secret 'default/supersecret2' must be updated"
+time="2018-11-28T00:15:15Z" level=info msg="secret 'default/supersecret2' updated"
+```
+
+```
+➜  kubectl get secrets
+NAME                  TYPE                                  DATA      AGE
+default-token-9k5dv   kubernetes.io/service-account-token   3         34d
+supersecret1          kubernetes.io/tls                     2         22h
+supersecret2          Opaque                                2         22h
+vault-token-secret    Opaque                                1         22h
+```
+

--- a/examples/secrets-manager.yaml
+++ b/examples/secrets-manager.yaml
@@ -1,0 +1,146 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: demo-secrets-manager
+  name: demo-secrets-manager
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: demo-secrets-manager
+  labels:
+    app: demo-secrets-manager
+rules:
+- apiGroups: 
+  - ""
+  resources:
+  - "secrets"
+  verbs:
+  - "get"
+  - "list"
+  - "watch"
+  - "update"
+  - "delete"
+  - "create"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: demo-secrets-manager
+  namespace: default
+  labels:
+    app: demo-secrets-manager
+rules:
+- apiGroups: 
+  - ""
+  resources:
+  - "configmaps"
+  verbs:
+  - "get"
+  - "list"
+  - "watch"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: demo-secrets-manager
+  labels:
+    app: demo-secrets-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: demo-secrets-manager
+subjects:
+  - kind: ServiceAccount
+    name: demo-secrets-manager
+    namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: demo-secrets-manager
+  namespace: default
+  labels:
+    app: demo-secrets-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: demo-secrets-manager
+subjects:
+  - kind: ServiceAccount
+    name: demo-secrets-manager
+    namespace: default
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: secrets-manager-config
+  namespace: default
+data:
+  secretDefinitions: |-
+    - name: supersecret1
+      type: kubernetes.io/tls
+      namespaces:
+      - default
+      data:
+        tls.crt:
+          encoding: base64
+          path: secret/data/pathtosecret1
+          key: value
+        tls.key:
+          encoding: base64
+          path: secret/data/pathtosecret3
+          key: value
+
+    - name: supersecret2
+      type: Opaque
+      namespaces:
+      - default
+      data:
+        value1:
+          path: secret/data/pathtosecret1
+          key: value
+        value2:
+          path: secret/data/pathtosecret2
+          key: value
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+    deployment.kubernetes.io/revision: "1"
+  labels:
+    app: demo-secrets-manager
+  name: demo
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: demo-secrets-manager
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: demo-secrets-manager
+    spec:
+      serviceAccountName: demo-secrets-manager
+      containers:
+      - image: registry.hub.docker.com/secrets-manager:v0.1.0
+        imagePullPolicy: Never
+        name: demo
+        args:
+        - -vault.url=http://vault:8200
+        - -config.config-map=secrets-manager-config
+        - -log.level=info
+        env:
+        - name: VAULT_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: vault-token-secret
+              key: token
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always

--- a/examples/vault.yaml
+++ b/examples/vault.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vault
+  labels:
+    app: vault
+spec:
+  ports:
+    - name: vault
+      port: 8200
+      targetPort: 8200
+      protocol: TCP
+  selector:
+    app: vault
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: vault
+  name: vault
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: vault
+    spec:
+      containers:
+      - image: vault
+        name: vault
+        command:
+        - vault
+        args:
+        - server
+        - -dev
+        - -dev-listen-address=0.0.0.0:8200
+        ports:
+        - containerPort: 8200
+          name: vaultport
+          protocol: TCP
+        volumeMounts:
+        - name: root-home
+          mountPath: /root
+        env:
+        - name: VAULT_ADDR
+          value: http://localhost:8200
+      # This second container is a litle hack to initialize Vault with some secrets
+      - name: vault-setup
+        image: vault
+        command:
+        - sh
+        args:
+        - -c
+        - sleep 10 && vault kv put secret/pathtosecret1 "value=dmFsdWUxCg==" && vault kv put secret/pathtosecret2 "value=value2" && vault kv put secret/pathtosecret3 "value=dmFsdWUzCg==" && tail -f /dev/null
+        env:
+        - name: VAULT_ADDR
+          value: http://localhost:8200
+        volumeMounts:
+        - name: root-home
+          mountPath: /root
+      volumes:
+      - name: root-home
+        emptyDir: {}
+
+


### PR DESCRIPTION
Added a simple deployment example using K8s manifests. It also includes a dummy deployment of Vault.