### PR TITLE
fixes token lookup called being ignored when a token is revoked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,7 @@
 ### Added
 - Enable prometheus metrics
 - `cfg.backend-timeout` flag to specify a connection timeout to the secrets backend.
+
+### Fixed
+- Bad return condition in startTokenRenewer, so token lookup won't
+  happen in case of a token revoked.

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -44,7 +44,13 @@ func NewBackendClient(ctx context.Context, backend string, logger *log.Logger, c
 	}
 	switch backend {
 	case vaultBackendName:
-		client, err = vaultClient(ctx, logger, cfg)
+		vclient, verr := vaultClient(logger, cfg)
+		if verr != nil {
+			return nil, verr
+		}
+		vclient.startTokenRenewer(ctx)
+		client = vclient
+		err = verr
 	}
 	return &client, err
 }

--- a/examples/secrets-manager.yaml
+++ b/examples/secrets-manager.yaml
@@ -129,7 +129,7 @@ spec:
     spec:
       serviceAccountName: demo-secrets-manager
       containers:
-      - image: registry.hub.docker.com/secrets-manager:v0.1.1
+      - image: registry.hub.docker.com/secrets-manager:v0.2.0-rc.1
         imagePullPolicy: Never
         name: demo
         args:


### PR DESCRIPTION
- This fixes a bug of a token not being looked when it's revoked so not updating the relevant metrics
