### PR TITLE
Use Golang as base image for building binaries.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 vendor/
 build/
 Dockerfile
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Stage 0
 # Build binary file
-FROM golang:1.10-alpine
+FROM golang:1.11.5-alpine as builder
 ENV GLIDE_VERSION v0.13.2
 
 RUN wget "https://github.com/Masterminds/glide/releases/download/${GLIDE_VERSION}/glide-${GLIDE_VERSION}-linux-amd64.tar.gz" \
@@ -25,5 +25,5 @@ RUN make build-linux
 FROM alpine:3.8
 ARG PROJECT_SLUG=github.com/tuenti/secrets-manager
 LABEL maintainer="sre@tuenti.com"
-COPY --from=0 /go/src/$PROJECT_SLUG/build/secrets-manager /secrets-manager
+COPY --from=builder /go/src/$PROJECT_SLUG/build/secrets-manager /secrets-manager
 ENTRYPOINT ["/secrets-manager"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,14 @@
 # Stage 0
 # Build binary file
-FROM instrumentisto/glide:0.13.1-go1.10
+FROM golang:1.10-alpine
+ENV GLIDE_VERSION v0.13.2
 
-RUN apk add --update make
+RUN wget "https://github.com/Masterminds/glide/releases/download/${GLIDE_VERSION}/glide-${GLIDE_VERSION}-linux-amd64.tar.gz" \
+    && tar xf glide-${GLIDE_VERSION}-linux-amd64.tar.gz \
+    && cp linux-amd64/glide $GOPATH/bin/ \
+    && chmod +x $GOPATH/bin/glide
+
+RUN apk add --update git make
 
 ARG PROJECT_SLUG=github.com/tuenti/secrets-manager
 COPY glide.yaml /go/src/$PROJECT_SLUG/glide.yaml
@@ -18,5 +24,6 @@ RUN make build-linux
 # Build actual docker image
 FROM alpine
 ARG PROJECT_SLUG=github.com/tuenti/secrets-manager
+LABEL maintainer="sre@tuenti.com"
 COPY --from=0 /go/src/$PROJECT_SLUG/build/secrets-manager /secrets-manager
 ENTRYPOINT ["/secrets-manager"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN make build-linux
 
 # Stage 1
 # Build actual docker image
-FROM alpine
+FROM alpine:3.8
 ARG PROJECT_SLUG=github.com/tuenti/secrets-manager
 LABEL maintainer="sre@tuenti.com"
 COPY --from=0 /go/src/$PROJECT_SLUG/build/secrets-manager /secrets-manager


### PR DESCRIPTION
Avoid using deprecated third-party Docker images (https://github.com/instrumentisto/glide-docker-image). 