### PR TITLE
simplifies and makes clearer all vault prometheus metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v0.2.0-rc.2 - 2019-01-29
+
+### Added 
+- New `secrets_manager_vault_max_token_ttl` metric, so a user could alert based on this and `secrets_manager_token_ttl`
+  
+### Fixed
+- Deprecates `secrets_manager_vault_token_expired` metric as it was quite confusing since it's not really possible for `secrets-manager` to know when the token it's expired, just when it's "close to expire".
+- Renames counter metrics to follow the Prometheus naming standard with the `_total` suffix instead of `_count`.
+- Simplifies prometheus token renewal metrics by merging `secrets_manager_vault_token_lookup_errors_count` and `secrets_manager_vault_token_renew_errors_count` into one single metric `secrets_manager_vault_token_renewal_errors_total` with one more dimension called `vault_operation` which will be one of `lookup-self, renew-self, is-renewable`.
+
 ## v0.2.0-rc.1 - 2019-01-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -104,10 +104,9 @@ data:
 
 | Metric| Type| Description| Labels|
 | ------| ----|------------| ------|
-|`secrets_manager_vault_token_expired` | Gauge | Whether or not token TTL is under `vault.max-token-ttl`: 1 = expired; 0 = still valid | `"vault_address", "vault_engine", "vault_version", "vault_cluster_id", "vault_cluster_name"` |
+|`secrets_manager_vault_max_token_ttl` | Gauge | `secrets-manager` max Vault token TTL | `"vault_address", "vault_engine", "vault_version", "vault_cluster_id", "vault_cluster_name"` |
 |`secrets_manager_vault_token_ttl` | Gauge | Vault token TTL | `"vault_address", "vault_engine", "vault_version", "vault_cluster_id", "vault_cluster_name"` |
-|`secrets_manager_vault_token_lookup_errors_count`| Counter | Vault token lookup-self errors counter | `"vault_address", "vault_engine", "vault_version", "vault_cluster_id", "vault_cluster_name", "error"` |
-|`secrets_manager_vault_token_renew_errors_count`| Counter | Vault token renew-self errors counter | `"vault_address", "vault_engine", "vault_version", "vault_cluster_id", "vault_cluster_name", "error"` |
+|`secrets_manager_vault_token_renewal_errors_total`| Counter | Vault token renewal errors counter | `"vault_address", "vault_engine", "vault_version", "vault_cluster_id", "vault_cluster_name", "vault_operation", "error"` |
 |`secrets_manager_read_secret_errors_count`| Counter | Vault read operations counter | `"vault_address", "vault_engine", "vault_version", "vault_cluster_id", "vault_cluster_name", "path", "key", "error"` |
 | `secrets_manager_secret_sync_errors_count`| Counter |Secrets sync error counter|`"name", "namespace"`|
 |`secrets_manager_secret_last_updated`| Gauge |The last update timestamp as a Unix time (the number of seconds elapsed since January 1, 1970 UTC)|`"name", "namespace"`|

--- a/backend/vault_metrics_test.go
+++ b/backend/vault_metrics_test.go
@@ -16,13 +16,13 @@ const (
 	fakeVaultClusterName = "vault-fake"
 )
 
-func TestUpdateTokenExpired(t *testing.T) {
+func TestUpdateMaxTokenTTL(t *testing.T) {
 	metrics := newVaultMetrics(fakeVaultAddress, fakeVaultVersion, fakeVaultEngine, fakeVaultClusterID, fakeVaultClusterName)
-	tokenExpired.Reset()
-	metrics.updateVaultTokenExpiredMetric(1)
-	metricTokenExpired, _ := tokenExpired.GetMetricWithLabelValues(fakeVaultAddress, fakeVaultEngine, fakeVaultVersion, fakeVaultClusterID, fakeVaultClusterName)
+	maxTokenTTL.Reset()
+	metrics.updateVaultMaxTokenTTLMetric(600)
+	metricMaxTokenTTL, _ := maxTokenTTL.GetMetricWithLabelValues(fakeVaultAddress, fakeVaultEngine, fakeVaultVersion, fakeVaultClusterID, fakeVaultClusterName)
 
-	assert.Equal(t, 1.0, testutil.ToFloat64(metricTokenExpired))
+	assert.Equal(t, 600.0, testutil.ToFloat64(metricMaxTokenTTL))
 }
 
 func TestUpdateTokenTTL(t *testing.T) {
@@ -34,44 +34,44 @@ func TestUpdateTokenTTL(t *testing.T) {
 	assert.Equal(t, 300.0, testutil.ToFloat64(metricTokenTTL))
 }
 
-func TestUpdateTokenLookupErrorsCount(t *testing.T) {
+func TestUpdateTokenLookupErrorsTotal(t *testing.T) {
 	metrics := newVaultMetrics(fakeVaultAddress, fakeVaultVersion, fakeVaultEngine, fakeVaultClusterID, fakeVaultClusterName)
-	tokenLookupErrorsCount.Reset()
-	metrics.updateVaultTokenLookupErrorsCountMetric(errors.UnknownErrorType)
-	metricTokenLookupErrorsCount, _ := tokenLookupErrorsCount.GetMetricWithLabelValues(fakeVaultAddress, fakeVaultEngine, fakeVaultVersion, fakeVaultClusterID, fakeVaultClusterName, errors.UnknownErrorType)
+	tokenRenewalErrorsTotal.Reset()
+	metrics.updateVaultTokenRenewalErrorsTotalMetric(vaultLookupSelfOperationName, errors.UnknownErrorType)
+	metricTokenRenewalErrorsTotal, _ := tokenRenewalErrorsTotal.GetMetricWithLabelValues(fakeVaultAddress, fakeVaultEngine, fakeVaultVersion, fakeVaultClusterID, fakeVaultClusterName, vaultLookupSelfOperationName, errors.UnknownErrorType)
 
-	assert.Equal(t, 1.0, testutil.ToFloat64(metricTokenLookupErrorsCount))
+	assert.Equal(t, 1.0, testutil.ToFloat64(metricTokenRenewalErrorsTotal))
 }
 
-func TestUpdateTokenRenewErrorsCount(t *testing.T) {
+func TestUpdateTokenRenewErrorsTotal(t *testing.T) {
 	metrics := newVaultMetrics(fakeVaultAddress, fakeVaultVersion, fakeVaultEngine, fakeVaultClusterID, fakeVaultClusterName)
-	tokenRenewErrorsCount.Reset()
-	metrics.updateVaultTokenRenewErrorsCountMetric(errors.UnknownErrorType)
-	metricTokenRenewErrorsCount, _ := tokenRenewErrorsCount.GetMetricWithLabelValues(fakeVaultAddress, fakeVaultEngine, fakeVaultVersion, fakeVaultClusterID, fakeVaultClusterName, errors.UnknownErrorType)
+	tokenRenewalErrorsTotal.Reset()
+	metrics.updateVaultTokenRenewalErrorsTotalMetric(vaultRenewSelfOperationName, errors.UnknownErrorType)
+	metricTokenRenewalErrorsTotal, _ := tokenRenewalErrorsTotal.GetMetricWithLabelValues(fakeVaultAddress, fakeVaultEngine, fakeVaultVersion, fakeVaultClusterID, fakeVaultClusterName, vaultRenewSelfOperationName, errors.UnknownErrorType)
 
-	assert.Equal(t, 1.0, testutil.ToFloat64(metricTokenRenewErrorsCount))
+	assert.Equal(t, 1.0, testutil.ToFloat64(metricTokenRenewalErrorsTotal))
 
-	tokenRenewErrorsCount.Reset()
-	metrics.updateVaultTokenRenewErrorsCountMetric(errors.VaultTokenNotRenewableErrorType)
-	metricTokenRenewErrorsCount, _ = tokenRenewErrorsCount.GetMetricWithLabelValues(fakeVaultAddress, fakeVaultEngine, fakeVaultVersion, fakeVaultClusterID, fakeVaultClusterName, errors.VaultTokenNotRenewableErrorType)
+	tokenRenewalErrorsTotal.Reset()
+	metrics.updateVaultTokenRenewalErrorsTotalMetric(vaultIsRenewableOperationName, errors.VaultTokenNotRenewableErrorType)
+	metricTokenRenewalErrorsTotal, _ = tokenRenewalErrorsTotal.GetMetricWithLabelValues(fakeVaultAddress, fakeVaultEngine, fakeVaultVersion, fakeVaultClusterID, fakeVaultClusterName, vaultIsRenewableOperationName, errors.VaultTokenNotRenewableErrorType)
 
-	assert.Equal(t, 1.0, testutil.ToFloat64(metricTokenRenewErrorsCount))
+	assert.Equal(t, 1.0, testutil.ToFloat64(metricTokenRenewalErrorsTotal))
 }
 
-func TestUpdateReadSecretErrorsCount(t *testing.T) {
+func TestUpdateReadSecretErrorsTotal(t *testing.T) {
 	path := "/path/to/secret"
 	key := "key"
 
 	metrics := newVaultMetrics(fakeVaultAddress, fakeVaultVersion, fakeVaultEngine, fakeVaultClusterID, fakeVaultClusterName)
-	secretReadErrorsCount.Reset()
-	metrics.updateVaultSecretReadErrorsCountMetric(path, key, errors.UnknownErrorType)
-	metricSecretReadErrorsCount, _ := secretReadErrorsCount.GetMetricWithLabelValues(fakeVaultAddress, fakeVaultEngine, fakeVaultVersion, fakeVaultClusterID, fakeVaultClusterName, path, key, errors.UnknownErrorType)
+	secretReadErrorsTotal.Reset()
+	metrics.updateVaultSecretReadErrorsTotalMetric(path, key, errors.UnknownErrorType)
+	metricSecretReadErrorsTotal, _ := secretReadErrorsTotal.GetMetricWithLabelValues(fakeVaultAddress, fakeVaultEngine, fakeVaultVersion, fakeVaultClusterID, fakeVaultClusterName, path, key, errors.UnknownErrorType)
 
-	assert.Equal(t, 1.0, testutil.ToFloat64(metricSecretReadErrorsCount))
+	assert.Equal(t, 1.0, testutil.ToFloat64(metricSecretReadErrorsTotal))
 
-	secretReadErrorsCount.Reset()
-	metrics.updateVaultSecretReadErrorsCountMetric(path, key, errors.BackendSecretNotFoundErrorType)
-	metricSecretReadErrorsCount, _ = secretReadErrorsCount.GetMetricWithLabelValues(fakeVaultAddress, fakeVaultEngine, fakeVaultVersion, fakeVaultClusterID, fakeVaultClusterName, path, key, errors.BackendSecretNotFoundErrorType)
+	secretReadErrorsTotal.Reset()
+	metrics.updateVaultSecretReadErrorsTotalMetric(path, key, errors.BackendSecretNotFoundErrorType)
+	metricSecretReadErrorsTotal, _ = secretReadErrorsTotal.GetMetricWithLabelValues(fakeVaultAddress, fakeVaultEngine, fakeVaultVersion, fakeVaultClusterID, fakeVaultClusterName, path, key, errors.BackendSecretNotFoundErrorType)
 
-	assert.Equal(t, 1.0, testutil.ToFloat64(metricSecretReadErrorsCount))
+	assert.Equal(t, 1.0, testutil.ToFloat64(metricSecretReadErrorsTotal))
 }


### PR DESCRIPTION
### Added 
- New `secrets_manager_vault_max_token_ttl` metric, so a user could alert based on this and `secrets_manager_token_ttl`
  
### Fixed
- Deprecates `secrets_manager_vault_token_expired` metric as it was quite confusing since it's not really possible for `secrets-manager` to actually not it's expired, just "close to expire".
- Renames counter metrics to follow the Prometheus naming standard with the `_total` suffix instead of `_count`.
- Simplifies prometheus token renewal metrics by merging `secrets_manager_vault_token_lookup_errors_count` and `secrets_manager_vault_token_renew_errors_count` into one single metric `secrets_manager_vault_token_renewal_errors_total` with one more dimension called `vault_operation` which will be one of `lookup-self, renew-self, is-renewable`.