### PR TITLE
Delete sdef if secret notfound

### DIFF
--- a/controllers/secretdefinition_controller.go
+++ b/controllers/secretdefinition_controller.go
@@ -229,7 +229,7 @@ func (r *SecretDefinitionReconciler) Reconcile(req ctrl.Request) (ctrl.Result, e
 	} else {
 		// SecretDefinition has been marked for deletion and contains finalizer
 		if containsString(sDef.ObjectMeta.Finalizers, finalizerName) {
-			if err = r.deleteSecret(secretNamespace, secretName); err != nil {
+			if err = r.deleteSecret(secretNamespace, secretName); err != nil && !errors.IsNotFound(err) {
 				log.Error(err, "unable to delete secret")
 				return ctrl.Result{}, ignoreNotFoundError(err)
 			}


### PR DESCRIPTION
Deleting a secretDefinition will hang if a secret doesn't exist yet. This can happen if the secret is not present in Vault and you prefer to delete the secretDefinition until you have it deployed in Vault.

Updating the finalizer associated with the secretDefinition to be just `[]` can fix it, but I just find more appropiate to just don't try to delete the secret if it does not exist