### PR TITLE
Add missing copy of hack folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ COPY api/ api/
 COPY controllers/ controllers/
 COPY backend/ backend/
 COPY errors/ errors/
+COPY hack/ hack/
 ARG SECRETS_MANAGER_VERSION
 
 # Build


### PR DESCRIPTION
Add missing copy of hack folder into container for build straight from Dockerfile. Thanks to @rvojcik for pointing it out.