### PR TITLE
Changes to make the container run as a non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,4 @@ FROM gcr.io/distroless/static:latest
 WORKDIR /
 COPY --from=builder /workspace/secrets-manager .
 ENTRYPOINT ["/secrets-manager"]
-USER 1000
+USER nobody

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,3 +29,4 @@ FROM gcr.io/distroless/static:latest
 WORKDIR /
 COPY --from=builder /workspace/secrets-manager .
 ENTRYPOINT ["/secrets-manager"]
+USER 1000


### PR DESCRIPTION
Fixes:

Secrets Manager should default to run as Non-Root #50