### PR TITLE
feat: Cluster role aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,14 @@ Secrets Manager can be run in one of 2 ways:
 
 In order for Secrets Manager to act as a manager for all Namespaces it requires a ClusterRole that enables it to manage all secrets and secretdefinitions in the entire Kubernetes cluster as in the [config/rbac/role.yaml](config/rbac/role.yaml) and [config/rbac/rolebinding.yaml](config/rbac/rolebinding.yaml) examples.
 
-Alternatively if you use the `watch-namespaces` argument to limit secretdefinition monitoring to sepcific namespaces then you can just give the `serviceAccount` that `secrets-manager` is running as a standard role and a rolebinding in each of the namespaces that you want it to manage as shown in the [config/rbac/secrets_manager_role.yaml](config/rbac/secrets_manager_role.yaml) and [config/rbac/secrets_manager_role_binding.yaml](config/rbac/secrets_manager_role_binding.yaml) examples.Alternatively you can still use a cluster role if you so wish.
+Alternatively if you use the `watch-namespaces` argument to limit secretdefinition monitoring to sepcific namespaces then you can just give the `serviceAccount` that `secrets-manager` is running as a standard role and a rolebinding in each of the namespaces that you want it to manage as shown in the [config/rbac/secrets_manager_role.yaml](config/rbac/secrets_manager_role.yaml) and [config/rbac/secrets_manager_role_binding.yaml](config/rbac/secrets_manager_role_binding.yaml) examples. Alternatively you can still use a cluster role if you so wish.
+
+To be able to interact with `secretdefinition` resources using the standard `admin`, `edit` and `view` Kubernetes native roles, you need to create the following `ClusterRole` aggregations:
+
+- [config/rbac/secretdefinitions_admin_clusterrole_aggregation.yaml](config/rbac/secretdefinitions_admin_clusterrole_aggregation.yaml)
+- [config/rbac/secretdefinitions_view_clusterrole_aggregation.yaml](config/rbac/secretdefinitions_view_clusterrole_aggregation.yaml)
+
+More information about aggregated `ClusterRoles` can be found at [kubernetes.io > Using RBAC Authorization > Aggregated ClusterRoles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles).
 
 ## Prometheus Metrics
 

--- a/config/rbac/secretdefinitions_admin_clusterrole_aggregation.yaml
+++ b/config/rbac/secretdefinitions_admin_clusterrole_aggregation.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: aggregate-secretdefinitions-admin-edit
+rules:
+- apiGroups:
+    - secrets-manager.tuenti.io
+  resources:
+    - secretdefinitions
+  verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
+    - deletecollection

--- a/config/rbac/secretdefinitions_view_clusterrole_aggregation.yaml
+++ b/config/rbac/secretdefinitions_view_clusterrole_aggregation.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
+  name: aggregate-secretdefinitions-view
+rules:
+- apiGroups:
+    - secrets-manager.tuenti.io
+  resources:
+    - secretdefinitions
+  verbs:
+    - get
+    - list
+    - watch


### PR DESCRIPTION
# Status

READY

# Migrations

NO

# Description

Adds the cluster role aggregations yaml files required to add `secretdefinitions` actions to `admin`,  `view` and `edit` native Kubernetes cluster roles.

# Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Check `admin` cluster role before and after applying the admin role aggregation:

```bash
❯ kubectl describe clusterrole admin | grep secrets-manager.tuenti.io

❯ kubectl apply -f config/rbac/secretdefinitions_admin_clusterrole_aggregation.yaml   
clusterrole.rbac.authorization.k8s.io/aggregate-secretdefinitions-admin-edit created

❯ kubectl describe clusterrole admin | grep secrets-manager.tuenti.io              
  secretdefinitions.secrets-manager.tuenti.io                []                 []                                      [get list watch create update patch delete deletecollection]
```

Check `view` cluster role before and after applying the admin role aggregation:

```bash         
❯ kubectl describe clusterrole view | grep secrets-manager.tuenti.io               

❯ kubectl apply -f config/rbac/secretdefinitions_view_clusterrole_aggregation.yaml
clusterrole.rbac.authorization.k8s.io/aggregate-secretdefinitions-view created

❯ kubectl describe clusterrole view | grep secrets-manager.tuenti.io              
  secretdefinitions.secrets-manager.tuenti.io               []                 []                                      [get list watch]
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~New and existing unit tests pass locally with my changes~
- [x] Any dependent changes have been merged and published in downstream modules
