### PR TITLE
Upgrade apiVersion of CRD and propagating annotations and labels from secret definition to secret

### DIFF
--- a/config/crd/patches/cainjection_in_secretdefinitions.yaml
+++ b/config/crd/patches/cainjection_in_secretdefinitions.yaml
@@ -1,6 +1,6 @@
 # The following patch adds a directive for certmanager to inject CA into the CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/config/crd/patches/webhook_in_secretdefinitions.yaml
+++ b/config/crd/patches/webhook_in_secretdefinitions.yaml
@@ -1,6 +1,6 @@
 # The following patch enables conversion webhook for CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: secretdefinitions.secrets-manager.tuenti.io

--- a/config/crd/secrets-manager.tuenti.io_secretdefinitions.yaml
+++ b/config/crd/secrets-manager.tuenti.io_secretdefinitions.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null


### PR DESCRIPTION
# Status

READY

# Migrations

Yes,
Migrating from **apiextensions.k8s.io/v1beta1** to **apiextensions.k8s.io/v1**

# Description

- Upgrading apiextensions.k8s.io/v1beta1 to apiextensions.k8s.io/v1
- Populating annotations and labels from secret definition to the created secret

# List of fixes # (issue)
  - fix #71 
  - fix #62 

# Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# How Has This Been Tested?
with secrets-manager tests

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
