### PR TITLE
K8s labels annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - [UPGRADE] Upgrade apiextensions.k8s.io from *v1beta1* to *v1*
 - [FEATURE] Populating Labels and Annotations from the SecretDefinition to the generated Secret.
-- [FEATURE] Updates the `managed-by` and `updatedAt` labels to more closely match k8s recommended values (using annotations and recommended labels), as seen below:
+- [ENHANCEMENT] Updates the `managed-by` and `updatedAt` labels to more closely match k8s recommended values (using annotations and recommended labels), as seen below:
 ```yaml
 annotations:
     secrets-manager.tuenti.io/lastUpdateTime: 2020-04-22T14.34.17Z

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## Pending to release
+
+- [UPGRADE] Upgrade apiextensions.k8s.io from *v1beta1* to *v1*
+- [FEATURE] Populating Labels and Annotations from the SecretDefinition to the generated Secret.
+- [FEATURE] Updates the `managed-by` and `updatedAt` labels to more closely match k8s recommended values (using annotations and recommended labels), as seen below:
+```yaml
+annotations:
+    secrets-manager.tuenti.io/lastUpdateTime: 2020-04-22T14.34.17Z
+labels:
+   app.kubernetes.io/managed-by: secrets-manager
+```
+
 ## v1.1.0 2021-01-05
 
 - [BEHAVIOUR] Using flags watch-namespaces / exclude-namespaces. They interact differently.

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -23,9 +23,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
+const (
+	Group   = "secrets-manager.tuenti.io"
+	Version = "v1alpha1"
+)
+
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "secrets-manager.tuenti.io", Version: "v1alpha1"}
+	GroupVersion = schema.GroupVersion{Group: Group, Version: Version}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/config/crd/bases/secrets-manager.tuenti.io_secretdefinitions.yaml
+++ b/config/crd/bases/secrets-manager.tuenti.io_secretdefinitions.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null

--- a/config/crd/patches/cainjection_in_secretdefinitions.yaml
+++ b/config/crd/patches/cainjection_in_secretdefinitions.yaml
@@ -1,6 +1,6 @@
 # The following patch adds a directive for certmanager to inject CA into the CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/config/crd/patches/webhook_in_secretdefinitions.yaml
+++ b/config/crd/patches/webhook_in_secretdefinitions.yaml
@@ -1,6 +1,6 @@
 # The following patch enables conversion webhook for CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: secretdefinitions.secrets-manager.tuenti.io

--- a/config/crd/secrets-manager.tuenti.io_secretdefinitions.yaml
+++ b/config/crd/secrets-manager.tuenti.io_secretdefinitions.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null

--- a/controllers/secretdefinition_controller.go
+++ b/controllers/secretdefinition_controller.go
@@ -51,6 +51,16 @@ type SecretDefinitionReconciler struct {
 	ExcludeNamespaces    map[string]bool
 }
 
+// Annotations to skip when copying from a SecretDef to a Secret
+var annotationsToSkip = map[string]bool{
+	corev1.LastAppliedConfigAnnotation: true,
+}
+
+// skipCopyAnnotation returns true if we should skip copying the annotation with the given annotation key
+func skipCopyAnnotation(key string) bool {
+	return annotationsToSkip[key]
+}
+
 // Helper functions to check and remove string from a slice of strings.
 func containsString(slice []string, s string) bool {
 	for _, item := range slice {
@@ -142,6 +152,9 @@ func (r *SecretDefinitionReconciler) upsertSecret(sDef *smv1alpha1.SecretDefinit
 	}
 
 	for k, v := range sDef.Annotations {
+		if skipCopyAnnotation(k) {
+			continue
+		}
 		annotations[k] = v
 	}
 

--- a/controllers/secretdefinition_controller.go
+++ b/controllers/secretdefinition_controller.go
@@ -54,9 +54,53 @@ type SecretDefinitionReconciler struct {
 // Annotations to skip when copying from a SecretDef to a Secret
 var annotationsToSkip = make(map[string]bool)
 
-// skipCopyAnnotation returns true if we should skip copying the annotation with the given annotation key
-func skipCopyAnnotation(key string) bool {
+// Helper functions to merge labels and annotations
+type skipfn func(string) bool
+
+func noSkip (_ string) bool {
+	return false
+}
+
+func skipAnnotation(key string) bool {
 	return annotationsToSkip[key]
+}
+
+func mergeMap(dst map[string]string, srcMap map[string]string, skipKey skipfn) {
+	for k, v := range srcMap {
+		if skipKey(k) {
+			continue
+		}
+		dst[k] = v
+	}
+}
+
+// Helper functions to manage corev1.Secret and smv1alpha1.SecretDefinition
+func getObjectMetaFromSecretDefinition(sDef *smv1alpha1.SecretDefinition) (metav1.ObjectMeta) {
+	labels := map[string]string{
+		managedByLabel: "secrets-manager",
+	}
+	annotations := map[string]string{
+		lastUpdateLabel: time.Now().Format(timestampFormat),
+	}
+
+	mergeMap(labels, sDef.Labels, noSkip)
+	mergeMap(annotations, sDef.Annotations, skipAnnotation)
+
+	return metav1.ObjectMeta{
+		Namespace: sDef.Namespace,
+		Name: sDef.Spec.Name,
+		Labels: labels,
+		Annotations: annotations,
+	}
+}
+
+func getSecretFromSecretDefinition(sDef *smv1alpha1.SecretDefinition, data map[string][]byte) (*corev1.Secret) {
+	objectMeta := getObjectMetaFromSecretDefinition(sDef)
+	return &corev1.Secret{
+		Type: corev1.SecretType(sDef.Spec.Type),
+		ObjectMeta: objectMeta,
+		Data: data,
+	}
 }
 
 // Helper functions to check and remove string from a slice of strings.
@@ -136,36 +180,7 @@ func (r *SecretDefinitionReconciler) getCurrentState(namespace string, name stri
 
 // upsertSecret will create or update a secret
 func (r *SecretDefinitionReconciler) upsertSecret(sDef *smv1alpha1.SecretDefinition, data map[string][]byte) error {
-	// Merge labels and annotations from the SecretDefinition
-	labels := map[string]string{
-		managedByLabel: "secrets-manager",
-	}
-
-	for k, v := range sDef.Labels {
-		labels[k] = v
-	}
-
-	annotations := map[string]string{
-		lastUpdateLabel: time.Now().Format(timestampFormat),
-	}
-
-	for k, v := range sDef.Annotations {
-		if skipCopyAnnotation(k) {
-			continue
-		}
-		annotations[k] = v
-	}
-
-	secret := &corev1.Secret{
-		Type: corev1.SecretType(sDef.Spec.Type),
-		ObjectMeta: metav1.ObjectMeta{
-			Annotations: annotations,
-			Labels:      labels,
-			Namespace:   sDef.Namespace,
-			Name:        sDef.Spec.Name,
-		},
-		Data: data,
-	}
+	secret := getSecretFromSecretDefinition(sDef, data)
 	err := r.Create(r.Ctx, secret)
 	if errors.IsAlreadyExists(err) {
 		err = r.Update(r.Ctx, secret)

--- a/controllers/secretdefinition_controller.go
+++ b/controllers/secretdefinition_controller.go
@@ -52,9 +52,7 @@ type SecretDefinitionReconciler struct {
 }
 
 // Annotations to skip when copying from a SecretDef to a Secret
-var annotationsToSkip = map[string]bool{
-	corev1.LastAppliedConfigAnnotation: true,
-}
+var annotationsToSkip = make(map[string]bool)
 
 // skipCopyAnnotation returns true if we should skip copying the annotation with the given annotation key
 func skipCopyAnnotation(key string) bool {
@@ -293,4 +291,9 @@ func (r *SecretDefinitionReconciler) SetupWithManager(mgr ctrl.Manager, name str
 		For(&smv1alpha1.SecretDefinition{}).
 		Named(name).
 		Complete(r)
+}
+
+func init() {
+	// last-applied-configuration should not be copied from the SecretDef to the Secret
+	annotationsToSkip[corev1.LastAppliedConfigAnnotation] = true
 }

--- a/controllers/secretdefinition_controller_test.go
+++ b/controllers/secretdefinition_controller_test.go
@@ -173,7 +173,8 @@ var _ = Describe("SecretsManager", func() {
 				Namespace: "default",
 				Name:      "secretdef-labels",
 				Annotations: map[string]string{
-					"tekton.dev/git-0": "github.com",
+					"tekton.dev/git-0":                         "github.com",
+					"kubernetes.io/last-applied-configuration": "test",
 				},
 				Labels: map[string]string{
 					"test.example.com/name": "test",
@@ -326,9 +327,14 @@ var _ = Describe("SecretsManager", func() {
 				"test.example.com/name":        "test"}))
 
 			annotations := secret.GetObjectMeta().GetAnnotations()
+			// lastUpdateTime annotation is created
 			_, ok := annotations["secrets-manager.tuenti.io/lastUpdateTime"]
 			Expect(ok).To(BeTrue())
+			// annotations from the SecretDef are passed to the secret
 			Expect(annotations["tekton.dev/git-0"]).To(Equal("github.com"))
+			// annotations to be skipped are not copied
+			_, ok2 := annotations["kubernetes.io/last-applied-configuration"]
+			Expect(ok2).ToNot(BeNil())
 		})
 		It("Create a secretdefinition in a non-watched namespace", func() {
 			r2 := getReconciler()

--- a/controllers/secretdefinition_controller_test.go
+++ b/controllers/secretdefinition_controller_test.go
@@ -172,6 +172,9 @@ var _ = Describe("SecretsManager", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "default",
 				Name:      "secretdef-labels",
+				Annotations: map[string]string{
+					"tekton.dev/git-0": "github.com",
+				},
 				Labels: map[string]string{
 					"test.example.com/name": "test",
 					"name":                  "secret-labels",
@@ -325,6 +328,7 @@ var _ = Describe("SecretsManager", func() {
 			annotations := secret.GetObjectMeta().GetAnnotations()
 			_, ok := annotations["secrets-manager.tuenti.io/lastUpdateTime"]
 			Expect(ok).To(BeTrue())
+			Expect(annotations["tekton.dev/git-0"]).To(Equal("github.com"))
 		})
 		It("Create a secretdefinition in a non-watched namespace", func() {
 			r2 := getReconciler()

--- a/controllers/secretdefinition_controller_test.go
+++ b/controllers/secretdefinition_controller_test.go
@@ -294,7 +294,6 @@ var _ = Describe("SecretsManager", func() {
 			Expect(res).To(Equal(reconcile.Result{}))
 		})
 		It("Create a secretdefinition and read the labels and annotations", func() {
-			//decodedBytes, _ := base64.StdEncoding.DecodeString(encodedValue)
 			err := r.Create(context.Background(), sdWithLabels)
 			Expect(err).To(BeNil())
 			res, err2 := r.Reconcile(reconcile.Request{

--- a/controllers/secretdefinition_controller_test.go
+++ b/controllers/secretdefinition_controller_test.go
@@ -12,11 +12,14 @@ import (
 
 	"reflect"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -165,6 +168,27 @@ var _ = Describe("SecretsManager", func() {
 				},
 			},
 		}
+		sdWithLabels = &smv1alpha1.SecretDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "secretdef-labels",
+				Labels: map[string]string{
+					"test.example.com/name": "test",
+					"name":                  "secret-labels",
+				},
+			},
+			Spec: smv1alpha1.SecretDefinitionSpec{
+				Name: "secret-labels",
+				Type: "Opaque",
+				KeysMap: map[string]smv1alpha1.DataSource{
+					"fooLabel": smv1alpha1.DataSource{
+						Path:     "secret/data/pathtosecret1",
+						Key:      "value",
+						Encoding: "base64",
+					},
+				},
+			},
+		}
 		sdExcludedNs = &smv1alpha1.SecretDefinition{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "default",
@@ -268,6 +292,73 @@ var _ = Describe("SecretsManager", func() {
 			})
 			Expect(reflect.TypeOf(err2)).To(Equal(reflect.TypeOf(expectedErr)))
 			Expect(res).To(Equal(reconcile.Result{}))
+		})
+		It("Create a secretdefinition and read the labels and annotations", func() {
+			//decodedBytes, _ := base64.StdEncoding.DecodeString(encodedValue)
+			err := r.Create(context.Background(), sdWithLabels)
+			Expect(err).To(BeNil())
+			res, err2 := r.Reconcile(reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: sdWithLabels.Namespace,
+					Name:      sdWithLabels.Name,
+				},
+			})
+			Expect(res).ToNot(BeNil())
+			Expect(err2).To(BeNil())
+
+			_, err3 := r.getCurrentState("default", "secret-labels")
+			Expect(err3).To(BeNil())
+
+			reader := r.APIReader
+			secret := &corev1.Secret{}
+			err4 := reader.Get(r.Ctx, client.ObjectKey{
+				Namespace: sdWithLabels.Namespace,
+				Name:      "secret-labels",
+			}, secret)
+			Expect(err4).To(BeNil())
+
+			labels := secret.GetObjectMeta().GetLabels()
+			Expect(labels).To(Equal(map[string]string{
+				"app.kubernetes.io/managed-by": "secrets-manager",
+				"name":                         "secret-labels",
+				"test.example.com/name":        "test"}))
+
+			annotations := secret.GetObjectMeta().GetAnnotations()
+			_, ok := annotations["secrets-manager.tuenti.io/lastUpdateTime"]
+			Expect(ok).To(BeTrue())
+		})
+		It("Create a secretdefinition in a non-watched namespace", func() {
+			r2 := getReconciler()
+			r2.WatchNamespaces = map[string]bool{"watch": true}
+			err := r.Create(context.Background(), sd3)
+			res, err2 := r.Reconcile(reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: sd3.Namespace,
+					Name:      sd3.Name,
+				},
+			})
+			Expect(err).To(BeNil())
+			Expect(err2).To(BeNil())
+			Expect(res).To(Equal(reconcile.Result{}))
+		})
+		It("Create a secretdefinition in a watched namespace", func() {
+			decodedBytes, _ := base64.StdEncoding.DecodeString(encodedValue)
+			r2 := getReconciler()
+			r2.WatchNamespaces = map[string]bool{sd4.Namespace: true}
+			err := r.Create(context.Background(), sd4)
+			res, err2 := r.Reconcile(reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: sd4.Namespace,
+					Name:      sd4.Name,
+				},
+			})
+			Expect(err).To(BeNil())
+			Expect(err2).To(BeNil())
+			Expect(res).ToNot(BeNil())
+
+			data, err3 := r.getCurrentState("default", "secret-test4")
+			Expect(err3).To(BeNil())
+			Expect(data).To(Equal(map[string][]byte{"foo4": decodedBytes}))
 		})
 		It("Create a secretdefinition in a excluded namespace", func() {
 			r2 := getReconciler()


### PR DESCRIPTION
# Status

READY

# Migrations

Yes,
Migrating from **apiextensions.k8s.io/v1beta1** to **apiextensions.k8s.io/v1**

# Description

- Resolving conflicts on PR #64 
  -  Populating annotations and labels from secret definition to the created secret 
  - Thanks to @stevendborrelli
- Upgrading apiextensions.k8s.io/v1beta1 to apiextensions.k8s.io/v1

# List of fixes # (issue)
  - fix #71 
  - fix #62 

# Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# How Has This Been Tested?
with secrets-manager tests

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
