### PR TITLE
fix nil pointer dereference bug in controller's regular kubernetes client

### DIFF
--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: registry.hub.docker.com/tuentitech/secrets-manager:v2.0.0
+      - image: registry.hub.docker.com/tuentitech/secrets-manager:v2.0.1
         name: manager

--- a/deploy/version/version.properties
+++ b/deploy/version/version.properties
@@ -1,1 +1,1 @@
-version=v2.0.0
+version=v2.0.1

--- a/main.go
+++ b/main.go
@@ -177,6 +177,7 @@ func main() {
 	}
 
 	if err = (&controllers.SecretDefinitionReconciler{
+		Client:               mgr.GetClient(),
 		Backend:              *backendClient,
 		APIReader:            mgr.GetAPIReader(),
 		Log:                  ctrl.Log.WithName("controllers").WithName("SecretDefinition"),


### PR DESCRIPTION
fixes #85 
# Status

READY

# Migrations

NO

# Description

fixes #85: 
As per the last release, the secretdefinition controller would only have apiReader clients, therefore using regular kubeclient (which uses controller's cache) was nil:

https://github.com/tuenti/secrets-manager/commit/933629df370702c43739adfd6777e0220655466d#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L146


# List of fixes # (issue)
  - fix #85
 
# Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested in a real k8s environment. Unit tests seem to pass.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
